### PR TITLE
Change vc to jinja2 and remove python build requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,14 +15,10 @@ source:
 build:
   number: 1
   features:
-    - vc9  # [win and py27]
-    - vc10  # [win and py34]
-    - vc14  # [win and py>=35]
-  skip: true  # [win and py36]
+    - vc{{ vc }} # [win]
 
 requirements:
   build:
-    - python  # [win]
     - {{ compiler('c') }}
 
 test:


### PR DESCRIPTION
Changed vc to use jinja2 templating and removed the Python build requirement. Tested on win-64