### PR TITLE
Use PBP supported way of disabling overlinking check.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,5 @@
 build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
   # See https://github.com/conda/conda-build/issues/3650
-  - "--no-error-overlinking"
+  # - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     - build_dll.patch   # [win]
 
 build:
-  number: 6
+  number: 7
   run_exports:
     - {{ pin_subpackage('bzip2') }}
 


### PR DESCRIPTION
Rebuild bzip2

### Changes
- Bump build number
- Previous build was built on prefect which allowed `- "--no-error-overlinking"`, PBP does not. Specify default build_parameters, but disable `error-overlinking`